### PR TITLE
Suppress `fopen` `E_WARINING`s and turn them to exceptions instead

### DIFF
--- a/src/KHerGe/File/File.php
+++ b/src/KHerGe/File/File.php
@@ -35,7 +35,14 @@ class File extends Stream
      */
     public function __construct($path, $mode)
     {
-        $stream = fopen($path, $mode);
+        $stream = @fopen($path, $mode);
+
+        $fopenError = error_get_last();
+        if ($fopenError) {
+            throw new ResourceException(
+                $fopenError['message']
+            );
+        }
 
         if (!$stream) {
             throw new ResourceException(

--- a/tests/KHerGe/File/FileTest.php
+++ b/tests/KHerGe/File/FileTest.php
@@ -3,6 +3,7 @@
 namespace Test\KHerGe\File;
 
 use KHerGe\File\File;
+use KHerGe\File\Exception\ResourceException;
 use PHPUnit_Framework_TestCase as TestCase;
 
 /**
@@ -41,6 +42,16 @@ class FileTest extends TestCase
             file_get_contents($this->file),
             'The file was not used by the stream manager.'
         );
+    }
+
+    /**
+     * Verify that opening a nonexistent file throws
+     * instead of writing a E_WARNING and throwing on `read()`.
+     */
+    public function testOpeningFileThatDoesNotExist()
+    {
+        $this->expectException(ResourceException::class);
+        $this->manager = new File(uniqid('nonexistent-file-'), 'r');
     }
 
     /**


### PR DESCRIPTION
### Before this patch
Currently the following snippet produces `E_WARNING` and then an actual exception
```php
$file = new File(uniqid('nonexistent-file-'), 'r');
```
What happens step by step is:
1. fopen raises a E_WARNING like this
```
LOW_PRIORITY_ERROR - [ErrorException] E_WARNING
fopen(nonexistent-file-asdf): failed to open stream: No such file or directory (0)
```
2. execution continues (I believe it depends on php configuration though)
3. a `ResourceException` is thrown by `File::__constuct`

A snippet like this still produces `E_WARNING` log, even though the `ResourceException` is handled (this was totally unexpected for me)
```php
try {
  $file = new File($path, 'r');
} catch (ResourceException $e) {
  // ignore
}
```

### After this patch
Since those old-school errors are so cumbersome to handle compared to exception and the snippet above produces garbage error logs, I modified this behavior to make `new File(...)` suppress `fopen`'s errors and instead rethrow them as a `ResourceException`s.